### PR TITLE
Release 1.5.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.xcuserstate
 Example/MobileConsentsSDK.xcodeproj/project.xcworkspace/xcuserdata/andrasmarczell.xcuserdatad/UserInterfaceState.xcuserstate
 Example/MobileConsentsSDK.xcodeproj/xcuserdata/andrasmarczell.xcuserdatad/xcdebugger/Breakpoints_v2.xcbkptlist
+.build

--- a/Example/MobileContentSolution/MobileConsentsSolutionViewModel.swift
+++ b/Example/MobileContentSolution/MobileConsentsSolutionViewModel.swift
@@ -10,6 +10,10 @@ final class MobileConsentSolutionViewModel {
                                                    fontSet: FontSet(largeTitle: .boldSystemFont(ofSize: 34),
                                                                     body: .monospacedSystemFont(ofSize: 14, weight: .regular),
                                                                     bold: .monospacedSystemFont(ofSize: 14, weight: .bold)),
+                                                       localizationOverride: [Locale.init(identifier: "en"): LabelText(
+                                                        title: "Data privacy",
+                                                        readMoreScreenHeader: "Data privacy explained"
+                                                       )],
                                                     enableNetworkLogger: true)
     
     
@@ -69,6 +73,9 @@ final class MobileConsentSolutionViewModel {
                                            solutionId: solutionId,
                                            accentColor: style.accentColor,
                                            fontSet: style.fontSet,
+                                           localizationOverride: [Locale.init(identifier: "en"): LabelText(
+                                            title: "Data privacy"
+                                           )],
                                            enableNetworkLogger: true
                                                         )
 

--- a/Example/MobileContentSolution/MobileConsentsSolutionViewModel.swift
+++ b/Example/MobileContentSolution/MobileConsentsSolutionViewModel.swift
@@ -33,7 +33,6 @@ final class MobileConsentSolutionViewModel {
         }
         return sectionTypes
     }
-
     var consentSolution: ConsentSolution?
 
     var savedConsents: [UserConsent] {

--- a/MobileConsentsSDK.podspec
+++ b/MobileConsentsSDK.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name         = 'MobileConsentsSDK'
-  spec.version      = '1.4.1'
+  spec.version      = '1.5.0'
   spec.platform = :ios, '11.0'
   spec.summary      = 'Cookie information iOS SDK'
   spec.homepage     = 'https://github.com/cookie-information/ios-release'

--- a/Sources/MobileConsentsSDK/Extensions/Bundle+module.swift
+++ b/Sources/MobileConsentsSDK/Extensions/Bundle+module.swift
@@ -1,4 +1,4 @@
 import Foundation
 internal extension Bundle {
-    static var current:Bundle { Bundle(for: MobileConsents.self) }
+    static var current: Bundle { Bundle(for: MobileConsents.self) }
 }

--- a/Sources/MobileConsentsSDK/Extensions/String+Extensions.swift
+++ b/Sources/MobileConsentsSDK/Extensions/String+Extensions.swift
@@ -8,6 +8,14 @@ extension String {
     var localized: String {
         NSLocalizedString(self, bundle: Bundle.current, comment: "")
     }
+    
+    internal var isValidURL:Bool {
+        let urlPattern = #"^(https?|ftp)://[^\s/$.?#].[^\s]*$"#  // Adjust the pattern as needed
+        let regex = try! NSRegularExpression(pattern: urlPattern)
+        
+        let range = NSRange(location: 0, length: self.utf16.count)
+        return regex.firstMatch(in: self, options: [], range: range) != nil
+    }
 }
 
 private final class BundleLocator {}

--- a/Sources/MobileConsentsSDK/MobileConsents.swift
+++ b/Sources/MobileConsentsSDK/MobileConsents.swift
@@ -14,6 +14,9 @@ public final class MobileConsents: NSObject, MobileConsentsProtocol {
     private let accentColor: UIColor
     private let fontSet: FontSet
     private let solutionId: String
+    
+    private var localizationOverride: [Locale: LabelText]
+    
     public typealias ConsentSolutionCompletion = (Result<ConsentSolution, Error>) -> ()
     
     /// Unique identifier of the user in Cookie Information records. This ID is assigned upon first run of the SDK
@@ -34,6 +37,7 @@ public final class MobileConsents: NSObject, MobileConsentsProtocol {
                                   solutionId: String,
                                   accentColor: UIColor? = nil,
                                   fontSet: FontSet = .standard,
+                                  localizationOverride: [Locale: LabelText] = [:],
                                   enableNetworkLogger: Bool = false) {
         
         self.init(localStorageManager: LocalStorageManager(),
@@ -43,10 +47,11 @@ public final class MobileConsents: NSObject, MobileConsentsProtocol {
                   solutionID: solutionId,
                   accentColor: accentColor,
                   fontSet: fontSet,
+                  localizationOverride: localizationOverride,
                   enableNetworkLogger: enableNetworkLogger)
     }
     
-    init(localStorageManager: LocalStorageManager, uiLanguageCode: String?, clientID: String, clientSecret: String, solutionID: String, accentColor: UIColor?, fontSet: FontSet, enableNetworkLogger: Bool) {
+    init(localStorageManager: LocalStorageManager, uiLanguageCode: String?, clientID: String, clientSecret: String, solutionID: String, accentColor: UIColor?, fontSet: FontSet, localizationOverride: [Locale: LabelText] = [:], enableNetworkLogger: Bool) {
         let jsonDecoder = JSONDecoder()
         jsonDecoder.userInfo[primaryLanguageCodingUserInfoKey] = uiLanguageCode
         
@@ -62,6 +67,7 @@ public final class MobileConsents: NSObject, MobileConsentsProtocol {
         )
         self.localStorageManager = localStorageManager
         self.solutionId = solutionID
+        self.localizationOverride = localizationOverride
     }
     
     /// Method responsible for fetching Consent Solutions.
@@ -124,8 +130,10 @@ public final class MobileConsents: NSObject, MobileConsentsProtocol {
             
             let consentSolutionManager = ConsentSolutionManager(
                 consentSolutionId: self.solutionId,
-                mobileConsents: self
-            )
+                mobileConsents: self,
+                localizationOverride: self.localizationOverride
+
+                )
             
             let router = Router(consentSolutionManager: consentSolutionManager, accentColor: self.accentColor, fontSet: self.fontSet)
             router.rootViewController = presentingViewController
@@ -187,6 +195,10 @@ public final class MobileConsents: NSObject, MobileConsentsProtocol {
     public func removeStoredConsents() {
         localStorageManager.clearAll()
     }
+    
+    public func setCustomLabels() {
+        
+    }
 }
 
 extension MobileConsents {
@@ -195,3 +207,4 @@ extension MobileConsents {
         localStorageManager.addConsentsArray(consents, versionId: consent.consentSolutionVersionId)
     }
 }
+

--- a/Sources/MobileConsentsSDK/Models/LabelText.swift
+++ b/Sources/MobileConsentsSDK/Models/LabelText.swift
@@ -1,0 +1,28 @@
+import Foundation
+@objc
+public class LabelText: NSObject {
+    @objc
+    public init(title: String?=nil, acceptAllButtonTitle: String?=nil, saveSelectionButtonTitle: String?=nil, privacyDescription: String?=nil, privacyPolicyLongtext: String?=nil, readMoreButton: String?=nil, requiredSectionHeader: String?=nil, optionalSectionHeader: String?=nil, readMoreScreenHeader: String?=nil) {
+        self.title = title
+        self.acceptAllButtonTitle = acceptAllButtonTitle
+        self.saveSelectionButtonTitle = saveSelectionButtonTitle
+        self.privacyDescription = privacyDescription
+        self.privacyPolicyLongtext = privacyPolicyLongtext
+        self.readMoreButton = readMoreButton
+        self.requiredSectionHeader = requiredSectionHeader
+        self.optionalSectionHeader = optionalSectionHeader
+        self.readMoreScreenHeader = readMoreScreenHeader
+    }
+    
+    public let title: String?
+    public let acceptAllButtonTitle: String?
+    public let saveSelectionButtonTitle: String?
+    public let privacyDescription: String?
+    public let privacyPolicyLongtext: String?
+    public let readMoreButton: String?
+    public let requiredSectionHeader: String?
+    public let optionalSectionHeader: String?
+    public let readMoreScreenHeader: String?
+    
+    
+}

--- a/Sources/MobileConsentsSDK/Models/TemplateTexts.swift
+++ b/Sources/MobileConsentsSDK/Models/TemplateTexts.swift
@@ -1,7 +1,20 @@
 import Foundation
 
 public class TemplateTexts: NSObject, Decodable {
-    public init(readMoreButton: Translated<TemplateTranslation>, rejectAllButton: Translated<TemplateTranslation>, acceptAllButton: Translated<TemplateTranslation>, acceptSelectedButton: Translated<TemplateTranslation>, savePreferencesButton: Translated<TemplateTranslation>, privacyCenterTitle: Translated<TemplateTranslation>, privacyPreferencesTabLabel: Translated<TemplateTranslation>, poweredByCoiLabel: Translated<TemplateTranslation>, consentPreferencesLabel: Translated<TemplateTranslation>) {
+    public init(
+        readMoreButton: Translated<TemplateTranslation>,
+        rejectAllButton: Translated<TemplateTranslation>,
+        acceptAllButton: Translated<TemplateTranslation>,
+        acceptSelectedButton: Translated<TemplateTranslation>,
+        savePreferencesButton: Translated<TemplateTranslation>,
+        privacyCenterTitle: Translated<TemplateTranslation>,
+        privacyPreferencesTabLabel: Translated<TemplateTranslation>,
+        poweredByCoiLabel: Translated<TemplateTranslation>,
+        consentPreferencesLabel: Translated<TemplateTranslation>,
+        readMoreScreenHeader: Translated<TemplateTranslation>?,
+        optionalTableSectionHeader: Translated<TemplateTranslation>?,
+        requiredTableSectionHeader: Translated<TemplateTranslation>?
+    ) {
         self.readMoreButton = readMoreButton
         self.rejectAllButton = rejectAllButton
         self.acceptAllButton = acceptAllButton
@@ -11,6 +24,9 @@ public class TemplateTexts: NSObject, Decodable {
         self.privacyPreferencesTabLabel = privacyPreferencesTabLabel
         self.poweredByCoiLabel = poweredByCoiLabel
         self.consentPreferencesLabel = consentPreferencesLabel
+        self.requiredTableSectionHeader = requiredTableSectionHeader
+        self.optionalTableSectionHeader = optionalTableSectionHeader
+        self.readMoreScreenHeader = readMoreScreenHeader
     }
     
     public let readMoreButton: Translated<TemplateTranslation>
@@ -22,6 +38,9 @@ public class TemplateTexts: NSObject, Decodable {
     public let privacyPreferencesTabLabel: Translated<TemplateTranslation>
     public let poweredByCoiLabel: Translated<TemplateTranslation>
     public let consentPreferencesLabel: Translated<TemplateTranslation>
+    public let requiredTableSectionHeader: Translated<TemplateTranslation>?
+    public let optionalTableSectionHeader: Translated<TemplateTranslation>?
+    public let readMoreScreenHeader: Translated<TemplateTranslation>?
     
     public enum CodingKeys: String, CodingKey {
         case readMoreButton = "privacyCenterButton"
@@ -32,6 +51,9 @@ public class TemplateTexts: NSObject, Decodable {
              privacyCenterTitle,
              privacyPreferencesTabLabel,
              poweredByCoiLabel,
-             consentPreferencesLabel
+             consentPreferencesLabel,
+             requiredTableSectionHeader,
+             optionalTableSectionHeader,
+             readMoreScreenHeader
     }
 }

--- a/Sources/MobileConsentsSDK/UI/ConsentSolutionManager.swift
+++ b/Sources/MobileConsentsSDK/UI/ConsentSolutionManager.swift
@@ -10,6 +10,7 @@ protocol ConsentSolutionManagerProtocol: ConsentItemProvider {
     var areAllRequiredConsentItemsSelected: Bool { get }
     var hasRequiredConsentItems: Bool { get }
     var settings: [ConsentItem] { get }
+    var localizationOverride: [Locale: LabelText] { get }
     func loadConsentSolutionIfNeeded(completion: @escaping (Result<ConsentSolution, Error>) -> Void)
     
     func rejectAllConsentItems(completion: @escaping (Error?) -> Void)
@@ -18,6 +19,8 @@ protocol ConsentSolutionManagerProtocol: ConsentItemProvider {
 }
 
 final class ConsentSolutionManager: ConsentSolutionManagerProtocol {
+    var localizationOverride: [Locale: LabelText]
+    
     static let consentItemSelectionDidChange = Notification.Name(rawValue: "com.cookieinformation.consentItemSelectionDidChange")
     
     var areAllRequiredConsentItemsSelected: Bool {
@@ -62,12 +65,14 @@ final class ConsentSolutionManager: ConsentSolutionManagerProtocol {
         consentSolutionId: String,
         mobileConsents: MobileConsentsProtocol,
         notificationCenter: NotificationCenter = NotificationCenter.default,
-        asyncDispatcher: AsyncDispatcher = DispatchQueue.main
+        asyncDispatcher: AsyncDispatcher = DispatchQueue.main,
+        localizationOverride: [Locale: LabelText] = [:]
     ) {
         self.consentSolutionId = consentSolutionId
         self.mobileConsents = mobileConsents
         self.notificationCenter = notificationCenter
         self.asyncDispatcher = asyncDispatcher
+        self.localizationOverride = localizationOverride
     }
     
     func loadConsentSolutionIfNeeded(completion: @escaping (Result<ConsentSolution, Error>) -> Void) {
@@ -126,6 +131,10 @@ final class ConsentSolutionManager: ConsentSolutionManagerProtocol {
     
     func acceptSelectedConsentItems(completion: @escaping (Error?) -> Void) {
         postConsent(selectedConsentItemIds: selectedConsentItemIds, completion: completion)
+    }
+    
+    func setLocalizationOverride(_ labels: NSDictionary) {
+        
     }
     
     private func postConsent(selectedConsentItemIds: Set<String>, completion: @escaping (Error?) -> Void) {

--- a/Sources/MobileConsentsSDK/UI/MobileConsentsMock.swift
+++ b/Sources/MobileConsentsSDK/UI/MobileConsentsMock.swift
@@ -62,19 +62,37 @@ private let mockConsentSolution = ConsentSolution(
         ),
         privacyPreferencesTabLabel: Translated(
             translations: [
-                TemplateTranslation(language: "EN", text: "Privacy preferences tab")
+                TemplateTranslation(language: "EN", text: "Privacy center title")
             ],
             primaryLanguage: languageCode
         ),
         poweredByCoiLabel: Translated(
             translations: [
-                TemplateTranslation(language: "EN", text: "Powered by Cookie Information")
+                TemplateTranslation(language: "EN", text: "Privacy preferences tab")
             ],
             primaryLanguage: languageCode
         ),
         consentPreferencesLabel: Translated(
             translations: [
-                TemplateTranslation(language: "EN", text: "Consent preferences label")
+                TemplateTranslation(language: "EN", text: "Powered by Cookie Information")
+            ],
+            primaryLanguage: languageCode
+        ),
+        readMoreScreenHeader: Translated(
+            translations: [
+                TemplateTranslation(language: "EN", text: "Privacy policy")
+            ],
+            primaryLanguage: languageCode
+        ),
+        optionalTableSectionHeader: Translated(
+            translations: [
+                TemplateTranslation(language: "EN", text: "Optional")
+            ],
+            primaryLanguage: languageCode
+        ),
+        requiredTableSectionHeader: Translated(
+            translations: [
+                TemplateTranslation(language: "EN", text: "Required")
             ],
             primaryLanguage: languageCode
         )

--- a/Sources/MobileConsentsSDK/UI/PopUp/PrivacyPolicyDetail.swift
+++ b/Sources/MobileConsentsSDK/UI/PopUp/PrivacyPolicyDetail.swift
@@ -13,10 +13,16 @@ public class PrivacyPolicyDetail: UIViewController {
     }()
     private lazy var barItem: UINavigationItem = {
         let item = UINavigationItem()
-        item.leftBarButtonItem = UIBarButtonItem(image: UIImage(named: "xmark", in: .module, compatibleWith: nil), style: .plain, target: self, action: #selector(close))
-        item.leftBarButtonItem?.tintColor = accentColor
+        item.leftBarButtonItem = UIBarButtonItem(image: UIImage(
+                                                            named: "xmark",
+                                                            in: .module,
+                                                            compatibleWith: nil),
+                                                 style: .plain,
+                                                 target: self,
+                                                 action: #selector(close))
         
-        item.title = "Privacy policy"
+        item.leftBarButtonItem?.tintColor = accentColor
+        item.title = self.title
         return item
     }()
     
@@ -51,10 +57,13 @@ public class PrivacyPolicyDetail: UIViewController {
     }()
     private var accentColor: UIColor
     private var text: String
-    public init(text: String, accentColor: UIColor) {
+    
+    public init(text: String, accentColor: UIColor,
+                title: String) {
         self.accentColor = accentColor
         self.text = text
         super.init(nibName: nil, bundle: nil)
+        self.title = title
         
     }
     required init?(coder: NSCoder) {

--- a/Sources/MobileConsentsSDK/UI/PopUp/PrivacyPolicyDetail.swift
+++ b/Sources/MobileConsentsSDK/UI/PopUp/PrivacyPolicyDetail.swift
@@ -11,10 +11,9 @@ public class PrivacyPolicyDetail: UIViewController {
         bar.translatesAutoresizingMaskIntoConstraints = false
         return bar
     }()
-    
     private lazy var barItem: UINavigationItem = {
         let item = UINavigationItem()
-        item.leftBarButtonItem = UIBarButtonItem(image: UIImage(named: "xmark", in: .current, compatibleWith: nil), style: .plain, target: self, action: #selector(close))
+        item.leftBarButtonItem = UIBarButtonItem(image: UIImage(named: "xmark", in: .module, compatibleWith: nil), style: .plain, target: self, action: #selector(close))
         item.leftBarButtonItem?.tintColor = accentColor
         
         item.title = "Privacy policy"

--- a/Sources/MobileConsentsSDK/UI/PopUp/PrivacyPolicyDetail.swift
+++ b/Sources/MobileConsentsSDK/UI/PopUp/PrivacyPolicyDetail.swift
@@ -1,4 +1,5 @@
 import UIKit
+import WebKit
 
 public class PrivacyPolicyDetail: UIViewController {
     
@@ -20,12 +21,18 @@ public class PrivacyPolicyDetail: UIViewController {
         return item
     }()
     
-    private lazy var webView: HTMLTextView = {
+    private lazy var richTextView: HTMLTextView = {
         let view = HTMLTextView()
         view.translatesAutoresizingMaskIntoConstraints = false
         view.font = .systemFont(ofSize: 14)
         view.isEditable = false
         view.style = StyleConstants.textViewStyle
+        return view
+    }()
+    
+    private lazy var webView: WKWebView = {
+        let view = WKWebView()
+        view.translatesAutoresizingMaskIntoConstraints = false
         return view
     }()
     
@@ -44,11 +51,11 @@ public class PrivacyPolicyDetail: UIViewController {
         return label
     }()
     private var accentColor: UIColor
-    
+    private var text: String
     public init(text: String, accentColor: UIColor) {
         self.accentColor = accentColor
+        self.text = text
         super.init(nibName: nil, bundle: nil)
-        webView.htmlText = text.wrappedInHtml
         
     }
     required init?(coder: NSCoder) {
@@ -62,15 +69,33 @@ public class PrivacyPolicyDetail: UIViewController {
     }
     
     private func setup() {
-        view.addSubview(webView)
         view.addSubview(navigationBar)
         view.addSubview(deviceInfoLabel)
-    
+        
+        
+        var contentConstraints: [NSLayoutConstraint] = [NSLayoutConstraint]()
+
+        if text.isValidURL, let url = URL(string: self.text) {
+            view.addSubview(webView)
+            contentConstraints = [
+                webView.topAnchor.constraint(equalTo: navigationBar.bottomAnchor, constant: 18),
+                webView.leadingAnchor.constraint(equalTo: view.layoutMarginsGuide.leadingAnchor),
+                webView.trailingAnchor.constraint(equalTo: view.layoutMarginsGuide.trailingAnchor),
+                webView.bottomAnchor.constraint(equalTo: deviceInfoLabel.topAnchor),
+            ]
+            webView.load(URLRequest(url: url))
+        } else {
+            view.addSubview(richTextView)
+            contentConstraints = [
+                richTextView.topAnchor.constraint(equalTo: navigationBar.bottomAnchor, constant: 18),
+                richTextView.leadingAnchor.constraint(equalTo: view.layoutMarginsGuide.leadingAnchor),
+                richTextView.trailingAnchor.constraint(equalTo: view.layoutMarginsGuide.trailingAnchor),
+                richTextView.bottomAnchor.constraint(equalTo: deviceInfoLabel.topAnchor),
+            ]
+            richTextView.htmlText = self.text.wrappedInHtml
+        }
         NSLayoutConstraint.activate([
-            webView.topAnchor.constraint(equalTo: navigationBar.bottomAnchor, constant: 18),
-            webView.leadingAnchor.constraint(equalTo: view.layoutMarginsGuide.leadingAnchor),
-            webView.trailingAnchor.constraint(equalTo: view.layoutMarginsGuide.trailingAnchor),
-            webView.bottomAnchor.constraint(equalTo: deviceInfoLabel.topAnchor),
+            
             navigationBar.topAnchor.constraint(equalTo: view.topAnchor),
             navigationBar.leadingAnchor.constraint(equalTo: view.leadingAnchor),
             navigationBar.trailingAnchor.constraint(equalTo: view.trailingAnchor),
@@ -79,8 +104,10 @@ public class PrivacyPolicyDetail: UIViewController {
             deviceInfoLabel.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor, constant: 15),
             deviceInfoLabel.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor)
         ])
+        
+        NSLayoutConstraint.activate(contentConstraints)
     }
-             
+    
     @objc func displayDeviceId() {
         let id = LocalStorageManager().userId
         let alert = UIAlertController(title: "Device Identifier",

--- a/Sources/MobileConsentsSDK/UI/PopUp/PrivacyPopUpViewController.swift
+++ b/Sources/MobileConsentsSDK/UI/PopUp/PrivacyPopUpViewController.swift
@@ -194,9 +194,13 @@ final class PrivacyPopUpViewController: UIViewController, PrivacyPopupProtocol {
             self.privacyDescription.text = data.privacyDescription
             self.privacyPolicyLongtext = data.privacyPolicyLongtext
             self.readMoreButton.setTitle("\(data.readMoreButton) ", for: .normal)
-            let chevron = UIImage(named: "chevron", in: .current, compatibleWith: nil)
+            let chevron = UIImage(named: "chevron", in: .module, compatibleWith: nil)
+            
             self.readMoreButton.setImage(chevron, for: .normal)
+            self.readMoreButton.imageEdgeInsets = UIEdgeInsets(top: 2, left: 0, bottom: 2, right: 0)
             self.readMoreButton.semanticContentAttribute = .forceRightToLeft
+            
+            
             self.view.accessibilityElements = [self.titleView, self.privacyDescription, self.readMoreButton, self.tableView, self.navigationBar]
         }
         

--- a/Sources/MobileConsentsSDK/UI/PopUp/PrivacyPopUpViewController.swift
+++ b/Sources/MobileConsentsSDK/UI/PopUp/PrivacyPopUpViewController.swift
@@ -86,6 +86,7 @@ final class PrivacyPopUpViewController: UIViewController, PrivacyPopupProtocol {
     private let viewModel: PrivacyPopUpViewModelProtocol
     private var sections = [Section]()
     private let fontSet: FontSet
+    private var data: PrivacyPopUpData? = nil
     
     init(viewModel: PrivacyPopUpViewModelProtocol, accentColor: UIColor, fontSet: FontSet) {
         self.viewModel = viewModel
@@ -185,6 +186,7 @@ final class PrivacyPopUpViewController: UIViewController, PrivacyPopupProtocol {
     private func setupViewModel() {
         viewModel.onDataLoaded = { [weak self] data in
             guard let self = self else { return }
+            self.data = data
             self.sections = data.sections
             self.tableView.reloadData()
             self.titleView.text = data.title
@@ -228,7 +230,7 @@ extension PrivacyPopUpViewController: UITableViewDataSource, UITableViewDelegate
     
     func tableView(_ tableView: UITableView, titleForHeaderInSection
                    section: Int) -> String? {
-        return section == 0 ? "Required" : "Optional"
+        return section == 0 ? (self.data?.requiredSectionHeader ?? "Required") : (self.data?.optionalSectionHeader ?? "Optional")
     }
     
     func tableView(_ tableView: UITableView, willDisplayHeaderView view: UIView, forSection section: Int) {
@@ -247,7 +249,7 @@ extension PrivacyPopUpViewController {
     }
     
     @objc func openPrivacyPolicy() {
-        let detailView = PrivacyPolicyDetail(text: privacyPolicyLongtext, accentColor: accentColor)
+        let detailView = PrivacyPolicyDetail(text: privacyPolicyLongtext, accentColor: accentColor, title: data?.readMoreScreenHeader ?? "Privacy policy")
                
         present(detailView, animated: true)
     }
@@ -256,7 +258,7 @@ extension PrivacyPopUpViewController {
 
 extension String {
     init(key: String) {
-        self = NSLocalizedString(key, bundle: Bundle(for: PrivacyPopUpViewController.self), comment: "")
+        self = NSLocalizedString(key, bundle: .module, comment: "")
     }
 }
 

--- a/Sources/MobileConsentsSDK/UI/PopUp/PrivacyPopUpViewModel.swift
+++ b/Sources/MobileConsentsSDK/UI/PopUp/PrivacyPopUpViewModel.swift
@@ -2,14 +2,17 @@ import Foundation
 import UIKit
 
 public struct PrivacyPopUpData {
-    public let title: String
     public let sections: [PopUpConsentsSection]
+    
+    public let title: String
     public let acceptAllButtonTitle: String
     public let saveSelectionButtonTitle: String
-
     public let privacyDescription: String
     public let privacyPolicyLongtext: String
     public let readMoreButton: String
+    public let requiredSectionHeader: String
+    public let optionalSectionHeader: String
+    public let readMoreScreenHeader: String
 }
 
 protocol PrivacyPopUpViewModelProtocol: UINavigationBarDelegate {
@@ -60,17 +63,30 @@ public final class PrivacyPopUpViewModel: NSObject, PrivacyPopUpViewModelProtoco
             let optionalSection = PopUpConsentsSection(viewModels: self.consentViewModels(from: solution))
             let requiredSection = PopUpConsentsSection(viewModels: self.consentViewModels(from: solution, required: true))
             
+            let overrides = consentSolutionManager.localizationOverride[Locale(identifier: solution.primaryLanguage)]
+      
             let data = PrivacyPopUpData(
-                title: title,
                 sections: [
                     requiredSection,
                     optionalSection
                 ],
-                acceptAllButtonTitle: solution.templateTexts.acceptAllButton.primaryTranslation().text,
-                saveSelectionButtonTitle: solution.templateTexts.acceptSelectedButton.primaryTranslation().text,
-                privacyDescription: solution.consentItems.first { $0.type == .privacyPolicy}?.translations.primaryTranslation().shortText ?? "",
-                privacyPolicyLongtext: solution.consentItems.first { $0.type == .privacyPolicy}?.translations.primaryTranslation().longText ?? "",
-                readMoreButton: solution.templateTexts.readMoreButton.primaryTranslation().text
+                title: overrides?.title ?? title,
+                acceptAllButtonTitle: 
+                    overrides?.acceptAllButtonTitle ?? solution.templateTexts.acceptAllButton.primaryTranslation().text,
+                saveSelectionButtonTitle: 
+                    overrides?.saveSelectionButtonTitle ?? solution.templateTexts.acceptSelectedButton.primaryTranslation().text,
+                privacyDescription: 
+                    solution.consentItems.first { $0.type == .privacyPolicy}?.translations.primaryTranslation().shortText ?? "",
+                privacyPolicyLongtext: 
+                    solution.consentItems.first { $0.type == .privacyPolicy}?.translations.primaryTranslation().longText ?? "",
+                readMoreButton: 
+                    overrides?.readMoreButton ?? solution.templateTexts.readMoreButton.primaryTranslation().text,
+                requiredSectionHeader:
+                    overrides?.requiredSectionHeader ?? solution.templateTexts.requiredTableSectionHeader?.primaryTranslation().text ?? "Required",
+                optionalSectionHeader:
+                    overrides?.optionalSectionHeader ?? solution.templateTexts.optionalTableSectionHeader?.primaryTranslation().text ?? "Optional",
+                readMoreScreenHeader:
+                    overrides?.readMoreScreenHeader ?? solution.templateTexts.readMoreScreenHeader?.primaryTranslation().text ?? ""
             )
         
             self.onDataLoaded?(data)


### PR DESCRIPTION
change log:
- Added an option to the sdk initializer to override UI translations ( buttons, titles etc)
- If the privacy policy long text contains only a valid url, the read more button will now open that url in an in app browser instead of just rendering it as a link
- small bug fixes