### PR TITLE
Calling completion block on failure

### DIFF
--- a/Sources/MobileConsentsSDK/MobileConsents.swift
+++ b/Sources/MobileConsentsSDK/MobileConsents.swift
@@ -166,6 +166,7 @@ public final class MobileConsents: NSObject, MobileConsentsProtocol {
         synchronizeIfNeeded()
         self.fetchConsentSolution { result in
             guard case let .success(value) = result else {
+                completion?([])
                 return
             }
             


### PR DESCRIPTION
Calling the completion block in `showPrivacyPopUpIfNeeded` if the `fetchConsentSolution` fails

Closes #18 