### PR TITLE
Fix postConsent hanging indefinitely when token refresh fails

### DIFF
--- a/MobileConsentsSDK.podspec
+++ b/MobileConsentsSDK.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name         = 'MobileConsentsSDK'
-  spec.version      = '1.5.7'
+  spec.version      = '1.5.8'
   spec.platform = :ios, '11.0'
   spec.summary      = 'Cookie information iOS SDK'
   spec.homepage     = 'https://github.com/cookie-information/ios-release'

--- a/Sources/MobileConsentsSDK/MobileConsents.swift
+++ b/Sources/MobileConsentsSDK/MobileConsents.swift
@@ -128,6 +128,24 @@ public final class MobileConsents: NSObject, MobileConsentsProtocol {
         completion: (([UserConsent])->())? = nil,
         errorHandler: ((Error)->())? = nil
     ) {
+        synchronizeIfNeeded()
+        presentPrivacyPopUp(
+            customViewType: customViewType,
+            onViewController: presentingViewController,
+            animated: animated,
+            completion: completion,
+            errorHandler: errorHandler
+        )
+    }
+    
+    
+    private func presentPrivacyPopUp(
+        customViewType: PrivacyPopupProtocol.Type? = nil,
+        onViewController presentingViewController: UIViewController? = nil,
+        animated: Bool = true,
+        completion: (([UserConsent])->())? = nil,
+        errorHandler: ((Error)->())? = nil
+    ) {
         DispatchQueue.main.async {
             let presentingViewController = presentingViewController ?? UIApplication.shared.windows.first { $0.isKeyWindow }?.topViewController
             
@@ -135,7 +153,6 @@ public final class MobileConsents: NSObject, MobileConsentsProtocol {
                 consentSolutionId: self.solutionId,
                 mobileConsents: self,
                 localizationOverride: self.localizationOverride
-
                 )
             
             let router = Router(consentSolutionManager: consentSolutionManager, accentColor: self.accentColor, fontSet: self.fontSet)
@@ -143,9 +160,7 @@ public final class MobileConsents: NSObject, MobileConsentsProtocol {
            
             router.showPrivacyPopUp(popupController: customViewType, animated: animated, completion: completion, error: errorHandler)
         }
-       
     }
-    
     
     /// Method responsible for showing Privacy Pop Up screen if there has not been a consent recorded or if the consent
     /// - Parameters:
@@ -176,7 +191,7 @@ public final class MobileConsents: NSObject, MobileConsentsProtocol {
             
             guard !storedConsents.isEmpty && (storedVersionId == versionId || ignoreVersionChanges) else {
                 self.removeStoredConsents()
-                self.showPrivacyPopUp(customViewType: customViewType, completion: completion, errorHandler: errorHandler)
+                self.presentPrivacyPopUp(customViewType: customViewType, completion: completion, errorHandler: errorHandler)
                 return
             }
             

--- a/Sources/MobileConsentsSDK/Networking/Manager/NetworkManager.swift
+++ b/Sources/MobileConsentsSDK/Networking/Manager/NetworkManager.swift
@@ -88,16 +88,19 @@ final class NetworkManager {
         provider.request(.authorize(clientID: clientID,
                                     clientSecret: clientSecret)) { data, response, error in
             let decoder = JSONDecoder()
-          decoder.keyDecodingStrategy = .convertFromSnakeCase
-          guard let data = data else {
-            guard let error = error else  { return }
-            completion(.failure(error))
-            return }
+            decoder.keyDecodingStrategy = .convertFromSnakeCase
+            guard let data = data else {
+                completion(.failure(error ?? NetworkResponseError.noData))
+                return
+            }
           
-          let token = try? decoder.decode( AuthResponse.self, from: data)
-          self.token = token
-          guard let token = token else {return}
-          completion(.success(token))
+            do {
+                let token = try decoder.decode(AuthResponse.self, from: data)
+                self.token = token
+                completion(.success(token))
+            } catch {
+                completion(.failure(error))
+            }
         }
     }
     
@@ -105,9 +108,12 @@ final class NetworkManager {
       if let token = token, token.expiresIn > Date() {
         postConsent(consent: consent, completion: completion)
       } else {
-        authorize { repsponse in
-          if case .success(_) = repsponse {
+        authorize { response in
+          switch response {
+          case .success:
             self.postConsent(consent, completion: completion)
+          case .failure(let error):
+            completion(error)
           }
         }
       }


### PR DESCRIPTION
- Handle authorization failure in NetworkManager.postConsent by calling completion with the error instead of silently dropping it
- Fix all code paths in NetworkManager.authorize to always call completion (missing calls when data was nil without error, and when token decoding failed)
- Extract `presentPrivacyPopUp` to avoid double `synchronizeIfNeeded` calls when `showPrivacyPopUpIfNeeded` delegates to `showPrivacyPopUp`
- Add `synchronizeIfNeeded` to `showPrivacyPopUp` so previously failed consent uploads are retried regardless of which public API the developer uses